### PR TITLE
Inline text fix

### DIFF
--- a/lib/virtualize.js
+++ b/lib/virtualize.js
@@ -35,9 +35,9 @@ function parse(html) {
       parent_vnode = vnode;
     },
     ontext: function(text) {
-      if (vnode) {
-        vnode.children.push(new VirtualText(text));
-        var parent = vnode;
+      if (parent_vnode) {
+        parent_vnode.children.push(new VirtualText(text));
+        var parent = parent_vnode;
         parent.count++;
         while(parent = parent.parent) {
           parent.count++;

--- a/test/virtualize.js
+++ b/test/virtualize.js
@@ -25,7 +25,6 @@ describe('html-virtualize', function() {
 
     it('outputs text with inline formatting correctly', function() {
       var vtree = parse('<p>paragraph start <em>italic</em> paragraph end</p>');
-      console.log(require('util').inspect(vtree, true, 10, true));
       expect(vtree).to.have.property('count', 4);
       expect(vtree).to.have.property('tagName', 'p');
       expect(vtree).to.have.property('children');

--- a/test/virtualize.js
+++ b/test/virtualize.js
@@ -22,5 +22,19 @@ describe('html-virtualize', function() {
       vtree = parse('<div><p>Test</p>Test<span>Test</span></div>');
       expect(vtree).to.have.property('count', 5);
     });
+
+    it('outputs text with inline formatting correctly', function() {
+      var vtree = parse('<p>paragraph start <em>italic</em> paragraph end</p>');
+      console.log(require('util').inspect(vtree, true, 10, true));
+      expect(vtree).to.have.property('count', 4);
+      expect(vtree).to.have.property('tagName', 'p');
+      expect(vtree).to.have.property('children');
+      expect(vtree.children).to.have.property('length', 3);
+      expect(vtree.children[0]).to.have.property('text', 'paragraph start ');
+      expect(vtree.children[1]).to.have.property('tagName', 'em');
+      expect(vtree.children[1].children).to.have.property('length', 1);
+      expect(vtree.children[1].children[0]).to.have.property('text', 'italic');
+      expect(vtree.children[2]).to.have.property('text', ' paragraph end');
+    });
   });
 });


### PR DESCRIPTION
I found a problem where text that surrounded inline formatting (e.g. em tags) would not be parsed correctly. I have added a test and updated the parse algorithm to fix the issue.

Please let me know if you need anything else to get this merged.
